### PR TITLE
Upgrade github.com/kr/text to solve non go mod indirect dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/niemeyer/pretty
 
 go 1.12
 
-require github.com/kr/text v0.1.0
+require github.com/kr/text v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,3 @@
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=


### PR DESCRIPTION
`github.com/niemeyer/pretty` requires `github.com/kr/text@v0.1.0`
`github.com/kr/text@v0.1.0` requires `github.com/kr/pty@v1.1.1`

`github.com/kr/pty@v1.1.1` has no go.mod file so AFAIU it messes up dependency graphs of any package that indirectly requires `github.com/niemeyer/pretty`

`github.com/kr/text@v0.2.0` requires `github.com/creack/pty@v1.1.9` which has a `go.mod` file.

If this is accepted an upgrade of `github.com/niemeyer/pretty` in `gopkg.in/yaml.v3` would solve a few go.mod `// indirect` lines in all packages importing `gopkg.in/yaml.v3`.